### PR TITLE
Add subgraph attributes for cluster (#1)

### DIFF
--- a/package.dhall
+++ b/package.dhall
@@ -50,7 +50,8 @@ let maximalExample =
                         { id = "Node #1", port = None dhall-dot.Port }
                     , dhall-dot.vertex.subgraph
                         ( dhall-dot.subgraph
-                            { id = Some "Subgraph #0"
+                            { id = Some "cluster_0"
+                            , attributes = toMap { style = "filled" }
                             , statements =
                               [ dhall-dot.statement.node
                                   { nodeID =
@@ -75,6 +76,7 @@ let maximalExample =
               , dhall-dot.statement.subgraph
                   ( dhall-dot.subgraph
                       { id = Some "Subgraph #1"
+                      , attributes = [] : List dhall-dot.Attribute
                       , statements =
                         [ dhall-dot.statement.node
                             { nodeID =
@@ -96,7 +98,7 @@ let maximalExample =
               ]
             }
         ≡ ''
-          strict digraph "A" { "Node #0":n [ "color" = "red" ]; "Node #1"; "Node #0":n -> "Node #1" -> subgraph "Subgraph #0" { "Subgraph #0 - Node #0"; "Subgraph #0 - Node #1"; } [ "label" = "Label #0" ]; subgraph "Subgraph #1" { "Subgraph #1 - Node #0"; "Subgraph #1 - Node #1"; }; }
+          strict digraph "A" { "Node #0":n [ "color" = "red" ]; "Node #1"; "Node #0":n -> "Node #1" -> subgraph "cluster_0" { "style" = "filled"; "Subgraph #0 - Node #0"; "Subgraph #0 - Node #1"; } [ "label" = "Label #0" ]; subgraph "Subgraph #1" { "Subgraph #1 - Node #0"; "Subgraph #1 - Node #1"; }; }
           ''
 
 in  dhall-dot

--- a/render.dhall
+++ b/render.dhall
@@ -51,6 +51,10 @@ let attributeList =
       λ(`as` : List types.Attribute) →
         "[ ${Text/concatMapSep ", " types.Attribute attribute `as`} ]"
 
+let graphAttributeList =
+      λ(`as` : List types.Attribute) →
+        "${Text/concatMapSep "; " types.Attribute attribute `as`};"
+
 let attributeType =
       λ(t : types.AttributeType) →
         merge { graph = "graph", node = "node", edge = "edge" } t
@@ -110,7 +114,12 @@ let statement =
             }
           , vertex = { nodeID, subgraph = λ(x : Text) → x }
           , subgraph =
-              λ(x : { id : Optional Text, statements : List Text }) →
+              λ ( x
+                : { id : Optional Text
+                  , attributes : List types.Attribute
+                  , statements : List Text
+                  }
+                ) →
                 let renderedID =
                       merge
                         { None = [] : List Text
@@ -118,10 +127,16 @@ let statement =
                         }
                         x.id
 
+                let renderedAttributeList =
+                      if    List/null types.Attribute x.attributes
+                      then  [] : List Text
+                      else  [ graphAttributeList x.attributes ]
+
                 in  Text/concatSep
                       " "
                       (   renderedID
                         # [ "{" ]
+                        # renderedAttributeList
                         # List/map
                             Text
                             Text

--- a/types.dhall
+++ b/types.dhall
@@ -40,7 +40,10 @@ let Statement =
               , subgraph : types.SubGraph → types.Vertex
               }
           , subgraph :
-              { id : Optional Text, statements : List types.Statement } →
+              { id : Optional Text
+              , attributes : List Attribute
+              , statements : List types.Statement
+              } →
                 types.SubGraph
           }
         ) →
@@ -69,7 +72,10 @@ let Vertex =
               , subgraph : types.SubGraph → types.Vertex
               }
           , subgraph :
-              { id : Optional Text, statements : List types.Statement } →
+              { id : Optional Text
+              , attributes : List Attribute
+              , statements : List types.Statement
+              } →
                 types.SubGraph
           }
         ) →
@@ -98,7 +104,10 @@ let SubGraph =
               , subgraph : types.SubGraph → types.Vertex
               }
           , subgraph :
-              { id : Optional Text, statements : List types.Statement } →
+              { id : Optional Text
+              , attributes : List Attribute
+              , statements : List types.Statement
+              } →
                 types.SubGraph
           }
         ) →
@@ -137,7 +146,10 @@ let statement
                   , subgraph : types.SubGraph → types.Vertex
                   }
               , subgraph :
-                  { id : Optional Text, statements : List types.Statement } →
+                  { id : Optional Text
+                  , attributes : List Attribute
+                  , statements : List types.Statement
+                  } →
                     types.SubGraph
               }
             ) →
@@ -166,7 +178,10 @@ let statement
                   , subgraph : types.SubGraph → types.Vertex
                   }
               , subgraph :
-                  { id : Optional Text, statements : List types.Statement } →
+                  { id : Optional Text
+                  , attributes : List Attribute
+                  , statements : List types.Statement
+                  } →
                     types.SubGraph
               }
             ) →
@@ -201,7 +216,10 @@ let statement
                   , subgraph : types.SubGraph → types.Vertex
                   }
               , subgraph :
-                  { id : Optional Text, statements : List types.Statement } →
+                  { id : Optional Text
+                  , attributes : List Attribute
+                  , statements : List types.Statement
+                  } →
                     types.SubGraph
               }
             ) →
@@ -230,7 +248,10 @@ let statement
                   , subgraph : types.SubGraph → types.Vertex
                   }
               , subgraph :
-                  { id : Optional Text, statements : List types.Statement } →
+                  { id : Optional Text
+                  , attributes : List Attribute
+                  , statements : List types.Statement
+                  } →
                     types.SubGraph
               }
             ) →
@@ -259,7 +280,10 @@ let statement
                   , subgraph : types.SubGraph → types.Vertex
                   }
               , subgraph :
-                  { id : Optional Text, statements : List types.Statement } →
+                  { id : Optional Text
+                  , attributes : List Attribute
+                  , statements : List types.Statement
+                  } →
                     types.SubGraph
               }
             ) →
@@ -292,7 +316,10 @@ let vertex
                   , subgraph : types.SubGraph → types.Vertex
                   }
               , subgraph :
-                  { id : Optional Text, statements : List types.Statement } →
+                  { id : Optional Text
+                  , attributes : List Attribute
+                  , statements : List types.Statement
+                  } →
                     types.SubGraph
               }
             ) →
@@ -321,7 +348,10 @@ let vertex
                   , subgraph : types.SubGraph → types.Vertex
                   }
               , subgraph :
-                  { id : Optional Text, statements : List types.Statement } →
+                  { id : Optional Text
+                  , attributes : List Attribute
+                  , statements : List types.Statement
+                  } →
                     types.SubGraph
               }
             ) →
@@ -329,8 +359,17 @@ let vertex
       }
 
 let subgraph
-    : { id : Optional ID, statements : List Statement } → SubGraph
-    = λ(x : { id : Optional ID, statements : List Statement }) →
+    : { id : Optional ID
+      , attributes : List Attribute
+      , statements : List Statement
+      } →
+        SubGraph
+    = λ ( x
+        : { id : Optional ID
+          , attributes : List Attribute
+          , statements : List Statement
+          }
+        ) →
       λ(types : { Statement : Type, Vertex : Type, SubGraph : Type }) →
       λ ( constructors
         : { statement :
@@ -353,7 +392,10 @@ let subgraph
               , subgraph : types.SubGraph → types.Vertex
               }
           , subgraph :
-              { id : Optional Text, statements : List types.Statement } →
+              { id : Optional Text
+              , attributes : List Attribute
+              , statements : List types.Statement
+              } →
                 types.SubGraph
           }
         ) →
@@ -363,6 +405,7 @@ let subgraph
               let adapt = λ(s : Statement) → s types constructors
 
               in  List/map Statement types.Statement adapt x.statements
+          , attributes = x.attributes
           }
 
 let Directionality = < graph | digraph >


### PR DESCRIPTION
This change adds subgraph attributes. Note that this only work for
subgraph name whose starts with cluster:
  https://graphviz.org/Gallery/directed/cluster.html